### PR TITLE
멤버 비지니스 로직 추가 및 Exception 처리 추가

### DIFF
--- a/api/src/main/kotlin/com/parking/api/adapter/in/HelloController.kt
+++ b/api/src/main/kotlin/com/parking/api/adapter/in/HelloController.kt
@@ -13,9 +13,4 @@ class HelloController(
     fun hello(): String {
         return helloName
     }
-
-    @GetMapping("/test/token2")
-    fun token(): String {
-        return "success token"
-    }
 }

--- a/api/src/main/kotlin/com/parking/api/adapter/in/MemberCommandController.kt
+++ b/api/src/main/kotlin/com/parking/api/adapter/in/MemberCommandController.kt
@@ -1,6 +1,9 @@
 package com.parking.api.adapter.`in`
 
+import com.parking.api.adapter.`in`.dto.MemberInfoDTO
+import com.parking.api.adapter.`in`.dto.MemberInfoResponseDTO
 import com.parking.api.adapter.`in`.dto.SignUpDTO
+import com.parking.api.application.port.`in`.ModifyMemberInfoUseCase
 import com.parking.api.application.port.`in`.SaveMemberUseCase
 import com.parking.api.common.dto.SuccessResponseDTO
 import org.springframework.web.bind.annotation.PostMapping
@@ -11,14 +14,23 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/member")
 class MemberCommandController(
-    private val saveMemberUseCase: SaveMemberUseCase
+    private val saveMemberUseCase: SaveMemberUseCase,
+    private val modifyMemberInfoUseCase: ModifyMemberInfoUseCase
 ) {
     @PostMapping("/sign-up")
     fun signUp(
         @RequestBody signUpDTO: SignUpDTO
-    ): SuccessResponseDTO<String> {
+    ): SuccessResponseDTO<Boolean> {
         saveMemberUseCase.saveMember(signUpDTO.toMemberInfoVO(), signUpDTO.password)
 
-        return SuccessResponseDTO.success("가입 완료 페이지")
+        return SuccessResponseDTO.success(true)
+    }
+
+    @PostMapping("/modify")
+    fun modify(
+        @RequestBody memberInfoDTO: MemberInfoDTO
+    ): SuccessResponseDTO<MemberInfoResponseDTO> {
+
+        return SuccessResponseDTO.success(MemberInfoResponseDTO.from(modifyMemberInfoUseCase.modify(memberInfoDTO.to())))
     }
 }

--- a/api/src/main/kotlin/com/parking/api/adapter/in/MemberCommandController.kt
+++ b/api/src/main/kotlin/com/parking/api/adapter/in/MemberCommandController.kt
@@ -40,6 +40,8 @@ class MemberCommandController(
     fun revoke(
         @RequestParam memberId: String
     ): SuccessResponseDTO<Boolean> {
-        return SuccessResponseDTO.success(revokeMemberUseCase.revoke(memberId))
+        revokeMemberUseCase.revoke(memberId)
+
+        return SuccessResponseDTO.success(true)
     }
 }

--- a/api/src/main/kotlin/com/parking/api/adapter/in/MemberCommandController.kt
+++ b/api/src/main/kotlin/com/parking/api/adapter/in/MemberCommandController.kt
@@ -4,18 +4,21 @@ import com.parking.api.adapter.`in`.dto.MemberInfoDTO
 import com.parking.api.adapter.`in`.dto.MemberInfoResponseDTO
 import com.parking.api.adapter.`in`.dto.SignUpDTO
 import com.parking.api.application.port.`in`.ModifyMemberInfoUseCase
+import com.parking.api.application.port.`in`.RevokeMemberUseCase
 import com.parking.api.application.port.`in`.SaveMemberUseCase
 import com.parking.api.common.dto.SuccessResponseDTO
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/member")
 class MemberCommandController(
     private val saveMemberUseCase: SaveMemberUseCase,
-    private val modifyMemberInfoUseCase: ModifyMemberInfoUseCase
+    private val modifyMemberInfoUseCase: ModifyMemberInfoUseCase,
+    private val revokeMemberUseCase: RevokeMemberUseCase
 ) {
     @PostMapping("/sign-up")
     fun signUp(
@@ -30,7 +33,13 @@ class MemberCommandController(
     fun modify(
         @RequestBody memberInfoDTO: MemberInfoDTO
     ): SuccessResponseDTO<MemberInfoResponseDTO> {
-
         return SuccessResponseDTO.success(MemberInfoResponseDTO.from(modifyMemberInfoUseCase.modify(memberInfoDTO.to())))
+    }
+
+    @PostMapping("/revoke")
+    fun revoke(
+        @RequestParam memberId: String
+    ): SuccessResponseDTO<Boolean> {
+        return SuccessResponseDTO.success(revokeMemberUseCase.revoke(memberId))
     }
 }

--- a/api/src/main/kotlin/com/parking/api/adapter/in/dto/MemberInfoDTO.kt
+++ b/api/src/main/kotlin/com/parking/api/adapter/in/dto/MemberInfoDTO.kt
@@ -1,0 +1,15 @@
+package com.parking.api.adapter.`in`.dto
+
+import com.parking.api.application.vo.MemberInfoVO
+
+data class MemberInfoDTO(
+    val memberId: String,
+    val memberName: String,
+    val memberEmail: String? = null
+) {
+    fun to() = MemberInfoVO(
+        memberId = memberId,
+        memberName = memberName,
+        memberEmail = memberEmail
+    )
+}

--- a/api/src/main/kotlin/com/parking/api/adapter/out/MemberCommandAdapter.kt
+++ b/api/src/main/kotlin/com/parking/api/adapter/out/MemberCommandAdapter.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component
 class MemberCommandAdapter(
     private val memberJpaRepository: MemberJpaRepository
 ): SaveMemberPort {
-    override fun saveMember(member: Member) : Member {
-        return memberJpaRepository.save(MemberJpaEntity.from(member)).to()
+    override fun saveMember(member: Member) {
+        memberJpaRepository.save(MemberJpaEntity.from(member))
     }
 }

--- a/api/src/main/kotlin/com/parking/api/application/port/in/ModifyMemberInfoUseCase.kt
+++ b/api/src/main/kotlin/com/parking/api/application/port/in/ModifyMemberInfoUseCase.kt
@@ -1,0 +1,7 @@
+package com.parking.api.application.port.`in`
+
+import com.parking.api.application.vo.MemberInfoVO
+
+interface ModifyMemberInfoUseCase {
+    fun modify(memberInfoVO: MemberInfoVO): MemberInfoVO
+}

--- a/api/src/main/kotlin/com/parking/api/application/port/in/RevokeMemberUseCase.kt
+++ b/api/src/main/kotlin/com/parking/api/application/port/in/RevokeMemberUseCase.kt
@@ -1,5 +1,5 @@
 package com.parking.api.application.port.`in`
 
 interface RevokeMemberUseCase {
-    fun revoke(memberId: String): Boolean
+    fun revoke(memberId: String)
 }

--- a/api/src/main/kotlin/com/parking/api/application/port/in/RevokeMemberUseCase.kt
+++ b/api/src/main/kotlin/com/parking/api/application/port/in/RevokeMemberUseCase.kt
@@ -1,0 +1,5 @@
+package com.parking.api.application.port.`in`
+
+interface RevokeMemberUseCase {
+    fun revoke(memberId: String): Boolean
+}

--- a/api/src/main/kotlin/com/parking/api/application/port/out/SaveMemberPort.kt
+++ b/api/src/main/kotlin/com/parking/api/application/port/out/SaveMemberPort.kt
@@ -3,5 +3,5 @@ package com.parking.api.application.port.out
 import com.parking.domain.entity.Member
 
 interface SaveMemberPort {
-    fun saveMember(member: Member) : Member
+    fun saveMember(member: Member)
 }

--- a/api/src/main/kotlin/com/parking/api/application/service/MemberCommandService.kt
+++ b/api/src/main/kotlin/com/parking/api/application/service/MemberCommandService.kt
@@ -1,8 +1,12 @@
 package com.parking.api.application.service
 
 import com.parking.api.adapter.out.MemberCommandAdapter
+import com.parking.api.adapter.out.MemberInquiryAdapter
+import com.parking.api.application.port.`in`.ModifyMemberInfoUseCase
 import com.parking.api.application.port.`in`.SaveMemberUseCase
 import com.parking.api.application.vo.MemberInfoVO
+import com.parking.domain.exception.MemberException
+import com.parking.domain.exception.enum.ExceptionCode
 import mu.KLogging
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
@@ -10,9 +14,10 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MemberCommandService(
+    private val memberInquiryAdapter: MemberInquiryAdapter,
     private val memberCommandAdapter: MemberCommandAdapter,
     private val passwordEncoder: PasswordEncoder
-): SaveMemberUseCase {
+): SaveMemberUseCase, ModifyMemberInfoUseCase {
 
     @Transactional
     override fun saveMember(memberInfoVO: MemberInfoVO, password: String) {
@@ -23,5 +28,17 @@ class MemberCommandService(
         logger.info (savedMember.getMemberId())
     }
 
+    override fun modify(memberInfoVO: MemberInfoVO): MemberInfoVO {
+        val member = memberInquiryAdapter.findMemberInfoByMemberId(memberInfoVO.memberId) ?: throw MemberException(
+            ExceptionCode.MEMBER_NOT_FOUND,
+            ExceptionCode.MEMBER_NOT_FOUND.message
+        )
+
+        member.modifyMemberInfo(memberInfoVO.memberName, memberInfoVO.memberEmail)
+
+        val savedMember = memberCommandAdapter.saveMember(member)
+
+        return MemberInfoVO.from(savedMember)
+    }
     companion object : KLogging()
 }

--- a/api/src/main/kotlin/com/parking/api/application/service/MemberCommandService.kt
+++ b/api/src/main/kotlin/com/parking/api/application/service/MemberCommandService.kt
@@ -3,8 +3,10 @@ package com.parking.api.application.service
 import com.parking.api.adapter.out.MemberCommandAdapter
 import com.parking.api.adapter.out.MemberInquiryAdapter
 import com.parking.api.application.port.`in`.ModifyMemberInfoUseCase
+import com.parking.api.application.port.`in`.RevokeMemberUseCase
 import com.parking.api.application.port.`in`.SaveMemberUseCase
 import com.parking.api.application.vo.MemberInfoVO
+import com.parking.domain.entity.Member
 import com.parking.domain.exception.MemberException
 import com.parking.domain.exception.enum.ExceptionCode
 import mu.KLogging
@@ -17,7 +19,7 @@ class MemberCommandService(
     private val memberInquiryAdapter: MemberInquiryAdapter,
     private val memberCommandAdapter: MemberCommandAdapter,
     private val passwordEncoder: PasswordEncoder
-): SaveMemberUseCase, ModifyMemberInfoUseCase {
+): SaveMemberUseCase, ModifyMemberInfoUseCase, RevokeMemberUseCase {
 
     @Transactional
     override fun saveMember(memberInfoVO: MemberInfoVO, password: String) {
@@ -29,16 +31,30 @@ class MemberCommandService(
     }
 
     override fun modify(memberInfoVO: MemberInfoVO): MemberInfoVO {
-        val member = memberInquiryAdapter.findMemberInfoByMemberId(memberInfoVO.memberId) ?: throw MemberException(
-            ExceptionCode.MEMBER_NOT_FOUND,
-            ExceptionCode.MEMBER_NOT_FOUND.message
-        )
+        val member = findMember(memberInfoVO.memberId)
 
         member.modifyMemberInfo(memberInfoVO.memberName, memberInfoVO.memberEmail)
 
         val savedMember = memberCommandAdapter.saveMember(member)
 
         return MemberInfoVO.from(savedMember)
+    }
+
+    override fun revoke(memberId: String): Boolean {
+        val member = findMember(memberId)
+
+        member.revoke()
+
+        memberCommandAdapter.saveMember(member)
+
+        return true
+    }
+
+    private fun findMember(memberId: String): Member {
+        return memberInquiryAdapter.findMemberInfoByMemberId(memberId) ?: throw MemberException(
+            ExceptionCode.MEMBER_NOT_FOUND,
+            ExceptionCode.MEMBER_NOT_FOUND.message
+        )
     }
     companion object : KLogging()
 }

--- a/api/src/main/kotlin/com/parking/api/application/service/MemberCommandService.kt
+++ b/api/src/main/kotlin/com/parking/api/application/service/MemberCommandService.kt
@@ -7,13 +7,11 @@ import com.parking.api.application.port.`in`.RevokeMemberUseCase
 import com.parking.api.application.port.`in`.SaveMemberUseCase
 import com.parking.api.application.vo.MemberInfoVO
 import com.parking.domain.entity.Member
-import com.parking.domain.entity.MemberStatus
 import com.parking.domain.exception.MemberException
 import com.parking.domain.exception.enum.ExceptionCode
 import mu.KLogging
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MemberCommandService(
@@ -22,7 +20,6 @@ class MemberCommandService(
     private val passwordEncoder: PasswordEncoder
 ): SaveMemberUseCase, ModifyMemberInfoUseCase, RevokeMemberUseCase {
 
-    @Transactional
     override fun saveMember(memberInfoVO: MemberInfoVO, password: String) {
         val member = memberInfoVO.toMember()
         member.password = passwordEncoder.encode(password)
@@ -35,19 +32,17 @@ class MemberCommandService(
 
         member.modifyMemberInfo(memberInfoVO.memberName, memberInfoVO.memberEmail)
 
-        val savedMember = memberCommandAdapter.saveMember(member)
+        memberCommandAdapter.saveMember(member)
 
-        return MemberInfoVO.from(savedMember)
+        return MemberInfoVO.from(member)
     }
 
-    override fun revoke(memberId: String): Boolean {
+    override fun revoke(memberId: String) {
         val member = findMember(memberId)
 
         member.revoke()
 
-        val savedMember = memberCommandAdapter.saveMember(member)
-
-        return savedMember.memberStatus == MemberStatus.REVOKED
+        memberCommandAdapter.saveMember(member)
     }
 
     private fun findMember(memberId: String): Member {

--- a/api/src/main/kotlin/com/parking/api/application/service/MemberCommandService.kt
+++ b/api/src/main/kotlin/com/parking/api/application/service/MemberCommandService.kt
@@ -7,6 +7,7 @@ import com.parking.api.application.port.`in`.RevokeMemberUseCase
 import com.parking.api.application.port.`in`.SaveMemberUseCase
 import com.parking.api.application.vo.MemberInfoVO
 import com.parking.domain.entity.Member
+import com.parking.domain.entity.MemberStatus
 import com.parking.domain.exception.MemberException
 import com.parking.domain.exception.enum.ExceptionCode
 import mu.KLogging
@@ -26,8 +27,7 @@ class MemberCommandService(
         val member = memberInfoVO.toMember()
         member.password = passwordEncoder.encode(password)
 
-        val savedMember = memberCommandAdapter.saveMember(member)
-        logger.info (savedMember.getMemberId())
+        memberCommandAdapter.saveMember(member)
     }
 
     override fun modify(memberInfoVO: MemberInfoVO): MemberInfoVO {
@@ -45,9 +45,9 @@ class MemberCommandService(
 
         member.revoke()
 
-        memberCommandAdapter.saveMember(member)
+        val savedMember = memberCommandAdapter.saveMember(member)
 
-        return true
+        return savedMember.memberStatus == MemberStatus.REVOKED
     }
 
     private fun findMember(memberId: String): Member {

--- a/api/src/main/kotlin/com/parking/api/application/service/MemberInquiryService.kt
+++ b/api/src/main/kotlin/com/parking/api/application/service/MemberInquiryService.kt
@@ -10,12 +10,12 @@ import com.parking.api.common.jwt.Token
 import com.parking.domain.entity.Member
 import com.parking.domain.exception.MemberException
 import com.parking.domain.exception.enum.ExceptionCode.*
+import com.parking.redis.service.RedisService
 import mu.KLogging
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.stereotype.Service
-import com.parking.redis.service.RedisService
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.*
 
@@ -43,6 +43,21 @@ class MemberInquiryService(
             throw MemberException(LOGIN_TRY_COUNT_LIMIT, LOGIN_TRY_COUNT_LIMIT.message)
         }
 
+        val member = findMemberPort.findMemberInfoByMemberId(memberId) ?: throw MemberException(
+            MEMBER_NOT_FOUND,
+            MEMBER_NOT_FOUND.message
+        )
+
+        //비밀번호 일치 여부 확인
+        if (!passwordEncoder.matches(password, member.password!!)) {
+            val uuid = UUID.randomUUID()
+            redisService.set("${memberId}_${uuid}", LocalDateTime.now().toString())
+
+            throw MemberException(PASSWORD_NOT_MATCH, PASSWORD_NOT_MATCH.message)
+        }
+
+        redisService.deleteStringValues(String.format("%s_*", memberId))
+
         try {
             // 인증시도
             authenticationManager.authenticate(
@@ -51,16 +66,6 @@ class MemberInquiryService(
         } catch (e: Exception) {
             // 인증 실패
             throw MemberException(AUTHENTICATION_FAIL, AUTHENTICATION_FAIL.message)
-        }
-
-        val member = findMemberPort.findMemberInfoByMemberId(memberId)
-
-        //비밀번호 일치 여부 확인
-        if (!passwordEncoder.matches(password, member?.password!!)) {
-            val uuid = UUID.randomUUID()
-            redisService.set("${memberId}_${uuid}", LocalDateTime.now().toString())
-
-            throw MemberException(PASSWORD_NOT_MATCH, PASSWORD_NOT_MATCH.message)
         }
 
         // Login이 성공한 경우 Token 생성
@@ -73,7 +78,7 @@ class MemberInquiryService(
     private fun checkPasswordTryCount(memberId: String) : Boolean {
         val values = redisService.getStringValues(String.format("%s_*", memberId))
 
-        return Member.LIMIT_PASSWORD_TRY_COUNT >= values.size
+        return Member.LIMIT_PASSWORD_TRY_COUNT > values.size
     }
 
     override fun refreshAccessToken(refreshToken: String): Token {

--- a/api/src/main/kotlin/com/parking/api/application/service/MemberInquiryService.kt
+++ b/api/src/main/kotlin/com/parking/api/application/service/MemberInquiryService.kt
@@ -56,6 +56,7 @@ class MemberInquiryService(
             throw MemberException(PASSWORD_NOT_MATCH, PASSWORD_NOT_MATCH.message)
         }
 
+        //입력한 비밀번호 일치할 경우 현재 redis 에 저장된 비밀번호가 틀린 기록을 모두 삭제
         redisService.deleteStringValues(String.format("%s_*", memberId))
 
         try {

--- a/api/src/main/kotlin/com/parking/api/common/advice/ParkingAdvice.kt
+++ b/api/src/main/kotlin/com/parking/api/common/advice/ParkingAdvice.kt
@@ -1,0 +1,22 @@
+package com.parking.api.common.advice
+
+import com.parking.api.common.dto.ExceptionResponseDTO
+import com.parking.domain.exception.BusinessException
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class ParkingAdvice {
+    @ExceptionHandler(BusinessException::class)
+    @ResponseStatus(HttpStatus.OK)
+    fun exceptionHandler(e: BusinessException): ExceptionResponseDTO<String> {
+        return ExceptionResponseDTO(e.exceptionCode, e.message)
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun exceptionHandler(e: Exception): ExceptionResponseDTO<String> {
+        return ExceptionResponseDTO(content = e.message)
+    }
+}

--- a/api/src/main/kotlin/com/parking/api/common/dto/ExceptionResponseDTO.kt
+++ b/api/src/main/kotlin/com/parking/api/common/dto/ExceptionResponseDTO.kt
@@ -1,0 +1,8 @@
+package com.parking.api.common.dto
+
+import com.parking.domain.exception.enum.ExceptionCode
+
+data class ExceptionResponseDTO<T> (
+    val code: ExceptionCode? = null,
+    val content: T?
+)

--- a/domain/src/main/kotlin/com/parking/domain/entity/Member.kt
+++ b/domain/src/main/kotlin/com/parking/domain/entity/Member.kt
@@ -20,12 +20,17 @@ data class Member(
     fun getMemberId(): String {
         return this.memberInfo.memberId
     }
+
+    fun modifyMemberInfo(name: String, email: String?) {
+        memberInfo.name = name
+        memberInfo.email = email
+    }
 }
 
 data class MemberInfo(
     val memberId: String,
-    val name: String,
-    val email: String? = null
+    var name: String,
+    var email: String? = null
 )
 
 enum class MemberStatus {

--- a/domain/src/main/kotlin/com/parking/domain/entity/Member.kt
+++ b/domain/src/main/kotlin/com/parking/domain/entity/Member.kt
@@ -25,6 +25,10 @@ data class Member(
         memberInfo.name = name
         memberInfo.email = email
     }
+
+    fun revoke() {
+        memberStatus = MemberStatus.REVOKED
+    }
 }
 
 data class MemberInfo(

--- a/persistence/src/main/kotlin/com/parking/jpa/entity/MemberJpaEntity.kt
+++ b/persistence/src/main/kotlin/com/parking/jpa/entity/MemberJpaEntity.kt
@@ -43,6 +43,7 @@ data class MemberJpaEntity (
 
     companion object {
         fun from(member: Member) = MemberJpaEntity(
+            id = member.id,
             memberId = member.memberInfo.memberId,
             password = member.password!!,
             memberName = member.memberInfo.name,

--- a/persistence/src/main/kotlin/com/parking/redis/service/RedisService.kt
+++ b/persistence/src/main/kotlin/com/parking/redis/service/RedisService.kt
@@ -8,4 +8,6 @@ interface RedisService<T> {
     fun set(key: String, value: T, duration: Duration = Duration.ofMinutes(10L))
 
     fun getStringValues(pattern: String): List<String>
+
+    fun deleteStringValues(pattern: String)
 }

--- a/persistence/src/main/kotlin/com/parking/redis/service/RedisServiceImpl.kt
+++ b/persistence/src/main/kotlin/com/parking/redis/service/RedisServiceImpl.kt
@@ -22,4 +22,8 @@ class RedisServiceImp<T>(
         val values = redissonClient.keys.getKeysByPattern(pattern)
         return values.map{ it }.toList()
     }
+
+    override fun deleteStringValues(pattern: String) {
+        redissonClient.keys.deleteByPattern(pattern)
+    }
 }


### PR DESCRIPTION
1. Advice를 이용하여 BusinessException 종류로 들어온 Exception들을 200번으로 처리할 수 있도록 추가
2. 로그인 시 패스워드가 맞을 경우 이전에 실패한 기록 삭제하는 기능 추가
3. 멤버 정보 수정 추가
4. 멤버 탈퇴 기능 추가